### PR TITLE
Fix C++ Definition Error

### DIFF
--- a/IccProfLib/IccCmm.h
+++ b/IccProfLib/IccCmm.h
@@ -81,7 +81,7 @@
 #include <cstring>
 #include <cstdlib>
 
-#if defined(__cpluplus) && defined(USEREFICCMAXNAMESPACE)
+#if defined(__cplusplus) && defined(USEREFICCMAXNAMESPACE)
 namespace refIccMAX {
 #endif
   


### PR DESCRIPTION
There was a small mispell in the #define 
__cpluplus
vs.
__cplusplus